### PR TITLE
Fixes copyright year.

### DIFF
--- a/cc-license.html
+++ b/cc-license.html
@@ -26,7 +26,7 @@
 {# The parameters all mirror the Creative Commone license chooser:          #}
 {# http://creativecommons.org/choose/                                       #}
 {# ------------------------------------------------------------------------ #}
-{# Copyright (c) 1994 Hilmar Lapp, hlapp@drycafe.net.                       #}
+{# Copyright (c) 2014 Hilmar Lapp, hlapp@drycafe.net.                       #}
 {# Licensed under the terms of the MIT License.                             #}
 {# Source at http://github.com/hlapp/cc-tools. Please fork & contribute.    #}
 {# ------------------------------------------------------------------------ #}


### PR DESCRIPTION
Not sure where and why the 1994 slipped in there. I certainly didn't write this back then, nor did Creative Commons exist then.