### PR TITLE
Fix title suffix

### DIFF
--- a/cc-license.html
+++ b/cc-license.html
@@ -37,6 +37,7 @@
                          attr_props={}) %}
   {% if cc_name %}
     {% set cc_name = cc_name|lower|replace("cc-","") %}
+    {% set cc_title_suffix = cc_name|replace("by", "")|replace("-nc","-NonCommercial")|replace("-nd","-NoDerivatives")|replace("-sa","-ShareAlike") %}
   {% else %}
     {% set cc_name = "by" %}
     {% set cc_title_suffix = "" %}

--- a/cc-license.html
+++ b/cc-license.html
@@ -52,7 +52,7 @@
       {% set cc_title_suffix = cc_title_suffix ~ "-ShareAlike" %}
     {% endif %}
   {% endif %}
-  {% set cc_title, cc_uri, cc_icon = ("Creative Commons Attribution 4.0 InternationalCCSUFFIX License","http://creativecommons.org/licenses/CCNAME/4.0/","//i.creativecommons.org/l/CCNAME/4.0/80x15.png") %}
+  {% set cc_title, cc_uri, cc_icon = ("Creative Commons AttributionCCSUFFIX 4.0 International License","http://creativecommons.org/licenses/CCNAME/4.0/","//i.creativecommons.org/l/CCNAME/4.0/80x15.png") %}
   <a rel="license" href="{{ cc_uri|replace('CCNAME',cc_name) }}"><img alt="Creative Commons License" style="border-width:0" src="{{ cc_icon|replace('CCNAME',cc_name) }}" /></a>
   {% if br_after_img %}<br/>{% endif %}
   {% if attr_markup %}


### PR DESCRIPTION
Fixes position and setting of suffix of the CC license long name for licenses more restrictive than CC-BY.

Closes #4 and closes #5. 