### PR TITLE
Changes http links to https

### DIFF
--- a/cc-license.html
+++ b/cc-license.html
@@ -24,11 +24,11 @@
 {#               specifying how under which title, to which creator, and    #}
 {#               to which URL to attribute the work                         #}
 {# The parameters all mirror the Creative Commone license chooser:          #}
-{# http://creativecommons.org/choose/                                       #}
+{# https://creativecommons.org/choose/                                      #}
 {# ------------------------------------------------------------------------ #}
 {# Copyright (c) 2014 Hilmar Lapp, hlapp@drycafe.net.                       #}
 {# Licensed under the terms of the MIT License.                             #}
-{# Source at http://github.com/hlapp/cc-tools. Please fork & contribute.    #}
+{# Source at https://github.com/hlapp/cc-tools. Please fork & contribute.   #}
 {# ------------------------------------------------------------------------ #}
 {% macro cc_license_mark(cc_name,
                          derivatives, commercial,
@@ -53,7 +53,7 @@
       {% set cc_title_suffix = cc_title_suffix ~ "-ShareAlike" %}
     {% endif %}
   {% endif %}
-  {% set cc_title, cc_uri, cc_icon = ("Creative Commons AttributionCCSUFFIX 4.0 International License","http://creativecommons.org/licenses/CCNAME/4.0/","//i.creativecommons.org/l/CCNAME/4.0/80x15.png") %}
+  {% set cc_title, cc_uri, cc_icon = ("Creative Commons AttributionCCSUFFIX 4.0 International License","https://creativecommons.org/licenses/CCNAME/4.0/","//i.creativecommons.org/l/CCNAME/4.0/80x15.png") %}
   <a rel="license" href="{{ cc_uri|replace('CCNAME',cc_name) }}"><img alt="Creative Commons License" style="border-width:0" src="{{ cc_icon|replace('CCNAME',cc_name) }}" /></a>
   {% if br_after_img %}<br/>{% endif %}
   {% if attr_markup %}


### PR DESCRIPTION
This is similar as a change set to getpelican/pelican-themes@cf3d1ed3bd47ec539993135bf193b0bead8abfe2 by @jeremyn. (Here we are also changing the link to the Github repo.)

Note that we aren't changing http IRIs identifying resources for machines, such as for XML namespaces and for Dublin Core terms.